### PR TITLE
Add prefer-console-info rule

### DIFF
--- a/docs/rules/prefer-console-info.md
+++ b/docs/rules/prefer-console-info.md
@@ -1,0 +1,39 @@
+# Enforce using console.info instead of console.log (prefer-console-info)
+
+This rule enforces the use of `console.info()` instead of `console.log()` for better logging practices.
+
+## Rule Details
+
+`console.info` is a better version of `console.log` and should always be used. It provides the same functionality as `console.log` but with additional semantic meaning, indicating that the message is informational in nature.
+
+Examples of **incorrect** code for this rule:
+
+```js
+console.log('hello world');
+console.log('User logged in:', userId);
+console.log(`Current temperature: ${temperature}°C`);
+console.log({ name: 'John', age: 30 });
+```
+
+Examples of **correct** code for this rule:
+
+```js
+console.info('hello world');
+console.info('User logged in:', userId);
+console.info(`Current temperature: ${temperature}°C`);
+console.info({ name: 'John', age: 30 });
+
+// Other console methods are still allowed
+console.error('An error occurred');
+console.warn('This is a warning');
+console.debug('Debug information');
+```
+
+## When Not To Use It
+
+If you have a specific reason to use `console.log` instead of `console.info` in your codebase, you might want to disable this rule.
+
+## Further Reading
+
+- [MDN Web Docs: console.info()](https://developer.mozilla.org/en-US/docs/Web/API/console/info)
+- [MDN Web Docs: console.log()](https://developer.mozilla.org/en-US/docs/Web/API/console/log)

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,6 +92,7 @@ import { omitIndexHtml } from './rules/omit-index-html';
 import { enforceIdCapitalization } from './rules/enforce-id-capitalization';
 import { noUnusedUseState } from './rules/no-unused-usestate';
 import { noUuidv4Base62AsKey } from './rules/no-uuidv4-base62-as-key';
+import { preferConsoleInfo } from './rules/prefer-console-info';
 
 module.exports = {
   meta: {
@@ -206,6 +207,7 @@ module.exports = {
         '@blumintinc/blumint/omit-index-html': 'error',
         '@blumintinc/blumint/enforce-id-capitalization': 'error',
         '@blumintinc/blumint/no-unused-usestate': 'error',
+        '@blumintinc/blumint/prefer-console-info': 'error',
       },
     },
   },
@@ -236,6 +238,7 @@ module.exports = {
     'no-unused-props': noUnusedProps,
     'no-useless-fragment': noUselessFragment,
     'no-uuidv4-base62-as-key': noUuidv4Base62AsKey,
+    'prefer-console-info': preferConsoleInfo,
     'prefer-fragment-shorthand': preferFragmentShorthand,
     'prefer-type-over-interface': preferTypeOverInterface,
     'require-memo': requireMemo,

--- a/src/rules/prefer-console-info.ts
+++ b/src/rules/prefer-console-info.ts
@@ -1,0 +1,52 @@
+import { createRule } from '../utils/createRule';
+import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils';
+
+type Options = [];
+type MessageIds = 'preferConsoleInfo';
+
+export const preferConsoleInfo = createRule<Options, MessageIds>({
+  name: 'prefer-console-info',
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Enforce using console.info instead of console.log',
+      recommended: 'error',
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      preferConsoleInfo: 'Use console.info instead of console.log',
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (
+          node.callee.type === AST_NODE_TYPES.MemberExpression &&
+          node.callee.property.type === AST_NODE_TYPES.Identifier &&
+          node.callee.property.name === 'log'
+        ) {
+          // Check if it's directly console.log or window.console.log
+          if (
+            (node.callee.object.type === AST_NODE_TYPES.Identifier && 
+             node.callee.object.name === 'console') ||
+            (node.callee.object.type === AST_NODE_TYPES.MemberExpression &&
+             node.callee.object.property.type === AST_NODE_TYPES.Identifier &&
+             node.callee.object.property.name === 'console')
+          ) {
+            context.report({
+              node,
+              messageId: 'preferConsoleInfo',
+              fix(fixer) {
+                const memberExpr = node.callee as TSESTree.MemberExpression;
+                const property = memberExpr.property as TSESTree.Identifier;
+                return fixer.replaceText(property, 'info');
+              },
+            });
+          }
+        }
+      },
+    };
+  },
+});

--- a/src/tests/prefer-console-info.test.ts
+++ b/src/tests/prefer-console-info.test.ts
@@ -1,0 +1,174 @@
+import { ruleTesterTs } from '../utils/ruleTester';
+import { preferConsoleInfo } from '../rules/prefer-console-info';
+
+ruleTesterTs.run('prefer-console-info', preferConsoleInfo, {
+  valid: [
+    {
+      code: 'console.info("hello world");',
+    },
+    {
+      code: 'console.error("error message");',
+    },
+    {
+      code: 'console.warn("warning message");',
+    },
+    {
+      code: 'console.debug("debug message");',
+    },
+    {
+      code: 'console.trace("trace message");',
+    },
+    {
+      code: 'console.table(data);',
+    },
+    {
+      code: 'console.dir(object);',
+    },
+    {
+      code: 'console.time("timer");',
+    },
+    {
+      code: 'console.timeEnd("timer");',
+    },
+    {
+      code: 'console.group("group");',
+    },
+    {
+      code: 'console.groupEnd();',
+    },
+    {
+      code: 'console.clear();',
+    },
+    {
+      code: 'console.count("counter");',
+    },
+    {
+      code: 'console.countReset("counter");',
+    },
+    {
+      code: 'console.assert(condition, "message");',
+    },
+    {
+      code: 'logger.log("hello world");',
+    },
+    {
+      code: 'const log = console.log; log("hello world");',
+    },
+    {
+      code: 'const { log } = console; log("hello world");',
+    },
+    {
+      code: 'const myConsole = { log: () => {} }; myConsole.log("hello world");',
+    },
+    {
+      code: 'window.console.info("hello world");',
+    },
+  ],
+  invalid: [
+    {
+      code: 'console.log("hello world");',
+      errors: [{ messageId: 'preferConsoleInfo' }],
+      output: 'console.info("hello world");',
+    },
+    {
+      code: 'console.log("hello", "world");',
+      errors: [{ messageId: 'preferConsoleInfo' }],
+      output: 'console.info("hello", "world");',
+    },
+    {
+      code: 'console.log(1, 2, 3);',
+      errors: [{ messageId: 'preferConsoleInfo' }],
+      output: 'console.info(1, 2, 3);',
+    },
+    {
+      code: 'console.log(`template literal`);',
+      errors: [{ messageId: 'preferConsoleInfo' }],
+      output: 'console.info(`template literal`);',
+    },
+    {
+      code: 'console.log(`template ${literal}`);',
+      errors: [{ messageId: 'preferConsoleInfo' }],
+      output: 'console.info(`template ${literal}`);',
+    },
+    {
+      code: 'console.log(variable);',
+      errors: [{ messageId: 'preferConsoleInfo' }],
+      output: 'console.info(variable);',
+    },
+    {
+      code: 'console.log(obj.property);',
+      errors: [{ messageId: 'preferConsoleInfo' }],
+      output: 'console.info(obj.property);',
+    },
+    {
+      code: 'console.log(arr[0]);',
+      errors: [{ messageId: 'preferConsoleInfo' }],
+      output: 'console.info(arr[0]);',
+    },
+    {
+      code: 'console.log(func());',
+      errors: [{ messageId: 'preferConsoleInfo' }],
+      output: 'console.info(func());',
+    },
+    {
+      code: 'console.log(...args);',
+      errors: [{ messageId: 'preferConsoleInfo' }],
+      output: 'console.info(...args);',
+    },
+    {
+      code: 'console.log({ a: 1, b: 2 });',
+      errors: [{ messageId: 'preferConsoleInfo' }],
+      output: 'console.info({ a: 1, b: 2 });',
+    },
+    {
+      code: 'console.log([1, 2, 3]);',
+      errors: [{ messageId: 'preferConsoleInfo' }],
+      output: 'console.info([1, 2, 3]);',
+    },
+    {
+      code: 'console.log(a ? b : c);',
+      errors: [{ messageId: 'preferConsoleInfo' }],
+      output: 'console.info(a ? b : c);',
+    },
+    {
+      code: 'console.log(a || b);',
+      errors: [{ messageId: 'preferConsoleInfo' }],
+      output: 'console.info(a || b);',
+    },
+    {
+      code: 'console.log(a && b);',
+      errors: [{ messageId: 'preferConsoleInfo' }],
+      output: 'console.info(a && b);',
+    },
+    {
+      code: 'console.log(a + b);',
+      errors: [{ messageId: 'preferConsoleInfo' }],
+      output: 'console.info(a + b);',
+    },
+    {
+      code: 'console.log(a - b);',
+      errors: [{ messageId: 'preferConsoleInfo' }],
+      output: 'console.info(a - b);',
+    },
+    {
+      code: 'console.log(a * b);',
+      errors: [{ messageId: 'preferConsoleInfo' }],
+      output: 'console.info(a * b);',
+    },
+    {
+      code: 'console.log(a / b);',
+      errors: [{ messageId: 'preferConsoleInfo' }],
+      output: 'console.info(a / b);',
+    },
+    {
+      code: 'console.log(a % b);',
+      errors: [{ messageId: 'preferConsoleInfo' }],
+      output: 'console.info(a % b);',
+    },
+    {
+      code: 'window.console.log("hello world");',
+      errors: [{ messageId: 'preferConsoleInfo' }],
+      output: 'window.console.info("hello world");',
+    },
+  ],
+});


### PR DESCRIPTION
## Description
This PR adds a new ESLint rule called `prefer-console-info` that enforces using `console.info()` instead of `console.log()` for better logging practices.

## Features
- Detects both direct `console.log` calls and `window.console.log` calls
- Provides auto-fix functionality to automatically replace `console.log` with `console.info`
- Includes comprehensive tests covering various use cases
- Adds documentation explaining the rule purpose and providing examples

## Implementation Details
- Created rule in `src/rules/prefer-console-info.ts`
- Added tests in `src/tests/prefer-console-info.test.ts`
- Added documentation in `docs/rules/prefer-console-info.md`
- Registered the rule in the plugin index.ts file
- Added the rule to the recommended configuration